### PR TITLE
Update tinyusb, drive EN pin on boost converter

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -82,7 +82,7 @@ add_executable(remapper
 if(PICO_BOARD STREQUAL "pico")
 target_compile_definitions(remapper PUBLIC PICO_DEFAULT_UART_TX_PIN=16)
 target_compile_definitions(remapper PUBLIC PICO_DEFAULT_UART_RX_PIN=17)
-target_compile_definitions(remapper PUBLIC PIO_USB_DP_PIN=0)
+target_compile_definitions(remapper PUBLIC PICO_DEFAULT_PIO_USB_DP_PIN=0)
 endif()
 
 target_include_directories(remapper PRIVATE

--- a/firmware/src/boards/feather_host.h
+++ b/firmware/src/boards/feather_host.h
@@ -53,8 +53,26 @@
 
 // --- PIO USB ---
 
-#ifndef PIO_USB_DP_PIN
-#define PIO_USB_DP_PIN 16
+// these are currently the defaults in tinyusb, but it has changed in the past
+
+#ifndef PICO_DEFAULT_PIO_USB_DP_PIN
+#define PICO_DEFAULT_PIO_USB_DP_PIN 16
 #endif
+
+#ifndef PICO_DEFAULT_PIO_USB_VBUSEN_PIN
+#define PICO_DEFAULT_PIO_USB_VBUSEN_PIN 18
+#endif
+
+// note that tinyusb defines PICO_DEFAULT_PIO_USB_VBUSEN_STATE in board.h,
+// but uses PIO_USB_VBUSEN_STATE in family.c
+
+#ifndef PIO_USB_VBUSEN_STATE
+#define PIO_USB_VBUSEN_STATE 1
+#endif
+
+// note that tinyusb uses PICO_DEFAULT_PIO_USB_VBUSEN_PIN for the pin number,
+// but PIO_USB_VBUSEN_PIN to decide whether to use it or not
+
+#define PIO_USB_VBUSEN_PIN
 
 #endif


### PR DESCRIPTION
Updates TinyUSB with the latest upstream changes and makes it so that pin 18 is driven high on the Feather USB Host board (connected to the enable pin on the boost converter supplying 5V to connected USB devices).

Please note there has been some confusing renaming of the Pico-PIO-USB related pin defines in TinyUSB.